### PR TITLE
Convert game actions from call to cast

### DIFF
--- a/lib/sengoku/game.ex
+++ b/lib/sengoku/game.ex
@@ -5,8 +5,9 @@ defmodule Sengoku.Game do
   @tiles_per_new_unit 3
   @battle_outcomes ~w(attacker defender)a
 
-  def initial_state(:hot_seat) do
+  def initial_state(game_id, :hot_seat) do
     %{
+      id: game_id,
       mode: :hot_seat,
       turn: 0,
       current_player_id: nil,
@@ -16,8 +17,9 @@ defmodule Sengoku.Game do
       tokens: %{}
     }
   end
-  def initial_state(:online) do
+  def initial_state(game_id, :online) do
     %{
+      id: game_id,
       mode: :online,
       turn: 0,
       current_player_id: nil,

--- a/lib/sengoku_web/channels/game_channel.ex
+++ b/lib/sengoku_web/channels/game_channel.ex
@@ -22,9 +22,7 @@ defmodule SengokuWeb.GameChannel do
     game_id = socket.assigns[:game_id]
     player_id = socket.assigns[:player_id]
     action = atomize_keys(action)
-    new_state = GameServer.action(game_id, player_id, action)
-
-    broadcast socket, "update", new_state
+    GameServer.action(game_id, player_id, action)
     {:noreply, socket}
   end
 

--- a/test/sengoku/game_test.exs
+++ b/test/sengoku/game_test.exs
@@ -161,7 +161,7 @@ defmodule Sengoku.GameTest do
 
   describe ".begin_turn" do
 
-    test "grants the current player 1 unit for every 3 owned territories" do
+    test "grants the current player 3 units plus 1 for every 3 owned territories" do
       old_state = %{
         current_player_id: 1,
         tiles: %{
@@ -188,7 +188,7 @@ defmodule Sengoku.GameTest do
 
       new_state = old_state |> Game.begin_turn
 
-      assert new_state.players[1].unplaced_units == 4
+      assert new_state.players[1].unplaced_units == 7
     end
 
     test "grants the current player at least 3 unplaced units" do

--- a/test/sengoku/game_test.exs
+++ b/test/sengoku/game_test.exs
@@ -6,7 +6,7 @@ defmodule Sengoku.GameTest do
   describe ".initial_state" do
 
     test "returns the state before the game begins" do
-      state = Game.initial_state(:hot_seat)
+      state = Game.initial_state("123", :hot_seat)
 
       assert state.mode == :hot_seat
       assert state.turn == 0


### PR DESCRIPTION
Before, we were only ever `broadcast`ing state updates as a result of player actions:

```ruby
def handle_in("action", action, socket) do
  game_id = socket.assigns[:game_id]
  player_id = socket.assigns[:player_id]
  action = atomize_keys(action)
  new_state = GameServer.action(game_id, player_id, action)

  broadcast socket, "update", new_state
  {:noreply, socket}
end
```

This is fine (if not ideal) in a game with only human players. But in preparation for supporting computer-controlled players, I'll need to update state as a result of server-initiated actions. The current approach cannot support this.

So instead of `broadcast`ing new state synchronously in the channel in response to user-initiated actions, we'll make this asynchronous: user-initiated actions will `cast` to the server, and whenever the server has handled them, it will `broadcast` them back to the players. This opens the door for the server arbitrarily `broadcast`ing new state for other reasons, such as server-initiated actions.

I should have done this from the start. With `GenServer`s it's a good idea to avoid `call` (which blocks the sending process) and prefer `cast` (which doesn't). If the `GameServer` ever takes a while to respond, `cast` means it won't also make the channel process slow to respond as well.