### PR TITLE
Holding a tile requires at least one unit

### DIFF
--- a/assets/js/components/Game.js
+++ b/assets/js/components/Game.js
@@ -38,7 +38,8 @@ class Game extends React.Component {
       // Moving or attacking
       if (player_owns_tile && this.state.selectedTileId !== id) {
         // Moving
-        const unitCount = prompt('How many units do you wish to move? (This will end your turn.)')
+        const maxMovableUnits = this.state.tiles[this.state.selectedTileId].units - 1
+        const unitCount = prompt('How many units do you wish to move? (Max: ' + maxMovableUnits + ') This will end your turn.')
         this.action('move', {
           from_id: this.state.selectedTileId,
           to_id: id,

--- a/lib/sengoku/ai/smart.ex
+++ b/lib/sengoku/ai/smart.ex
@@ -137,7 +137,7 @@ defmodule Sengoku.AI.Smart do
       type: "move",
       from_id: safe_owned_tile_id_with_most_units,
       to_id: friendly_neighbor_id,
-      count: units_in_safe_owned_tile_id_with_most_units
+      count: units_in_safe_owned_tile_id_with_most_units - 1
     }
   end
 
@@ -145,7 +145,7 @@ defmodule Sengoku.AI.Smart do
     state
     |> Tile.filter_ids(fn(tile) ->
          tile.owner == state.current_player_id &&
-         tile.units > 0 &&
+         tile.units > 1 &&
          tile.neighbors
          |> Enum.all?(fn(neighbor_id) ->
               neighbor = state.tiles[neighbor_id]

--- a/lib/sengoku/game.ex
+++ b/lib/sengoku/game.ex
@@ -106,7 +106,7 @@ defmodule Sengoku.Game do
     defender_id = to_tile.owner
 
     if (
-      from_tile.units > 0 &&
+      from_tile.units > 1 &&
       from_tile.owner == current_player_id &&
       defender_id != current_player_id &&
       to_id in from_tile.neighbors
@@ -143,7 +143,7 @@ defmodule Sengoku.Game do
     if (
       state.tiles[from_id].owner == current_player_id &&
       state.tiles[to_id].owner == current_player_id &&
-      count <= state.tiles[from_id].units &&
+      count < state.tiles[from_id].units &&
       from_id in state.tiles[to_id].neighbors
     ) do
       state

--- a/test/sengoku/game_test.exs
+++ b/test/sengoku/game_test.exs
@@ -337,23 +337,6 @@ defmodule Sengoku.GameTest do
       assert new_state.players[1].active == true
     end
 
-    test "does nothing when the last unowned tile is taken" do
-      old_state = %{
-        current_player_id: 1,
-        players: %{
-          1 => %Player{active: true, unplaced_units: 5},
-        },
-        tiles: %{
-          1 => %Tile{units: 2, owner: 1, neighbors: [2]},
-          2 => %Tile{units: 1, owner: nil, neighbors: [1]}
-        }
-      }
-
-      new_state = Game.attack(old_state, 1, 2, :attacker)
-      assert new_state.tiles[2].owner == 1
-      assert new_state.players[1].active == true
-    end
-
     test "when only one player remains active, they win!" do
       old_state = %{
         winner_id: nil,

--- a/test/sengoku/game_test.exs
+++ b/test/sengoku/game_test.exs
@@ -357,7 +357,7 @@ defmodule Sengoku.GameTest do
       assert new_state.winner_id == 1
     end
 
-    test "when the defender wins, the attacker loses an unit" do
+    test "when the defender wins, the attacker loses a unit" do
       old_state = %{
         current_player_id: 1,
         tiles: %{
@@ -371,11 +371,11 @@ defmodule Sengoku.GameTest do
       assert new_state.tiles[2].units == 2
     end
 
-    test "changes nothing if Player has no units in origin" do
+    test "changes nothing if Player has 1 unit in origin" do
       old_state = %{
         current_player_id: 1,
         tiles: %{
-          1 => %Tile{units: 0, owner: 1, neighbors: [2]},
+          1 => %Tile{units: 1, owner: 1, neighbors: [2]},
           2 => %Tile{units: 1, owner: 2, neighbors: [1]}
         }
       }
@@ -439,10 +439,10 @@ defmodule Sengoku.GameTest do
         },
       }
 
-      new_state = Game.move(old_state, 1, 2, 5)
+      new_state = Game.move(old_state, 1, 2, 4)
 
-      assert new_state.tiles[1].units == 0
-      assert new_state.tiles[2].units == 6
+      assert new_state.tiles[1].units == 1
+      assert new_state.tiles[2].units == 5
     end
 
     test "ends the Player’s turn" do
@@ -527,6 +527,23 @@ defmodule Sengoku.GameTest do
       }
 
       new_state = Game.move(old_state, 1, 2, 6)
+      assert new_state == old_state
+    end
+
+    test "does nothing if at least one unit won’t be left in the origin" do
+      old_state = %{
+        current_player_id: 1,
+        tiles: %{
+          1 => %Tile{owner: 1, units: 5, neighbors: [2]},
+          2 => %Tile{owner: 1, units: 1, neighbors: [1]},
+        },
+        players: %{
+          1 => %Player{active: true, unplaced_units: 0},
+          2 => %Player{active: true, unplaced_units: 0},
+        },
+      }
+
+      new_state = Game.move(old_state, 1, 2, 5)
       assert new_state == old_state
     end
 


### PR DESCRIPTION
Resolves #6
Resolves #7

It was somewhat confusing and offered no real benefit allowing players to leave 0 units in a tile while still owning it. This PR makes 2 related changes:

- Require at least 2 units in a tile to attack from it, so you can never attack with your last unit on a tile
- Prevent moving the last unit out of a tile. If a tile has 3 units, you can only move up to 2 of them. The move UI now tells you the maximum number of units you can move.

<img width="900" alt="screen shot 2017-10-15 at 8 18 44 am" src="https://user-images.githubusercontent.com/664341/31584725-7c4a4bea-b181-11e7-99ff-b3447798c627.png">
