### PR TITLE
Replace `prompt()` with a custom modal when choosing how many units to move

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -122,19 +122,22 @@ h2 {
           user-select: none;
 }
 
-.Overlay {
+.Modal {
   background: rgba($black, .75);
   position: fixed;
   top: 0;
-  width: 100%;
-  left: 0;
+  width: 80%;
+  left: 20%;
   z-index: $z-index-overlay;
   height: 100%;
   display: flex;
-  color: $white;
-  font-weight: bold;
   align-items: center;
   justify-content: center;
+}
+
+.GameOver {
+  color: $white;
+  font-weight: bold;
   font-size: 3em;
   text-shadow: 0 1px 2px $black;
   pointer-events: none;
@@ -242,3 +245,47 @@ h2 {
     }
   }
 }
+
+.MoveForm {
+  min-width: 50%;
+
+  &-slider {
+    display: flex;
+    font-size: 4em;
+    text-shadow: 0 1px 3px $black;
+
+    & > * {
+      margin: .5em;
+    }
+  }
+
+  &-setter {
+    border: none;
+    background: none;
+    font: inherit;
+    color: inherit;
+  }
+
+  &-input {
+    flex-grow: 1;
+    width: 100%;
+  }
+
+  &-actions {
+    display: flex;
+    justify-content: space-between;
+    // The "Submit" button must be first in the DOM so that it’s
+    // triggered on pressing [Enter], but it should appear last
+    // in the row, hence the reversed order.
+    flex-direction: row-reverse;
+
+    & > * {
+      margin-right: 1em;
+
+      &:first-child {
+        margin-right: 0;
+      }
+    }
+  }
+}
+

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -259,13 +259,6 @@ h2 {
     }
   }
 
-  &-setter {
-    border: none;
-    background: none;
-    font: inherit;
-    color: inherit;
-  }
-
   &-input {
     flex-grow: 1;
     width: 100%;

--- a/assets/js/components/MoveForm.js
+++ b/assets/js/components/MoveForm.js
@@ -1,5 +1,7 @@
 import React from 'react'
 
+const KEYCODE_ESCAPE = 27
+
 class MoveForm extends React.Component {
 
   constructor(props) {
@@ -7,6 +9,18 @@ class MoveForm extends React.Component {
     this.state = {
       value: props.maxUnits
     }
+  }
+
+  handleKeyup(event) {
+    if (event.keyCode === KEYCODE_ESCAPE) this.props.cancelMove(event)
+  }
+
+  componentDidMount() {
+    window.addEventListener("keyup", this.handleKeyup.bind(this));
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("keyup", this.handleKeyup);
   }
 
   handleSubmit(event) {

--- a/assets/js/components/MoveForm.js
+++ b/assets/js/components/MoveForm.js
@@ -1,0 +1,54 @@
+import React from 'react'
+
+class MoveForm extends React.Component {
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      value: props.maxUnits
+    }
+  }
+
+  handleSubmit(event) {
+    console.log('moving units', this.state.value)
+    this.props.submitMove(this.state.value);
+    event.preventDefault()
+  }
+
+  handleChange(event) {
+    this.setState({ value: event.target.value })
+  }
+
+  render() {
+    return (
+      <div className="Modal">
+        <form className="MoveForm" onSubmit={this.handleSubmit.bind(this)}>
+          <div className="MoveForm-slider">
+            <span>0</span>
+            <input className="MoveForm-input"
+                   type="range"
+                   min={0}
+                   max={this.props.maxUnits}
+                   value={this.state.value}
+                   onChange={this.handleChange.bind(this)}
+                   autoFocus
+            />
+            <span>{this.props.maxUnits}</span>
+          </div>
+          <div className="MoveForm-actions">
+            <input className="Button Button--primary"
+                   type="submit"
+                   value={'Move ' + this.state.value}
+            />
+            <button className="Button"
+                    onClick={this.props.cancelMove}
+                    children={'Cancel'}
+            />
+          </div>
+        </form>
+      </div>
+    )
+  }
+}
+
+export default MoveForm

--- a/assets/js/components/MoveForm.js
+++ b/assets/js/components/MoveForm.js
@@ -10,7 +10,6 @@ class MoveForm extends React.Component {
   }
 
   handleSubmit(event) {
-    console.log('moving units', this.state.value)
     this.props.submitMove(this.state.value);
     event.preventDefault()
   }
@@ -19,10 +18,20 @@ class MoveForm extends React.Component {
     this.setState({ value: event.target.value })
   }
 
+  halfMaxUnits() {
+    return Math.floor(this.props.maxUnits / 2)
+  }
+
+  moveHalf(event) {
+    this.props.submitMove(this.halfMaxUnits())
+    event.preventDefault()
+  }
+
   render() {
     return (
       <div className="Modal">
         <form className="MoveForm" onSubmit={this.handleSubmit.bind(this)}>
+          <h2>Move how many?</h2>
           <div className="MoveForm-slider">
             <span>0</span>
             <input className="MoveForm-input"
@@ -40,6 +49,12 @@ class MoveForm extends React.Component {
                    type="submit"
                    value={'Move ' + this.state.value}
             />
+            <button className="Button Button--primary"
+                    type="submit"
+                    onClick={this.moveHalf.bind(this)}
+            >
+              Move {this.halfMaxUnits()} (half)
+            </button>
             <button className="Button"
                     onClick={this.props.cancelMove}
                     children={'Cancel'}


### PR DESCRIPTION
Resolves #25 

Way better than `prompt()` because:

- you can just press [Enter] to move the maximum number of units, no need to type or do math
- the range input is autofocused, so you can use the arrow keys to choose how many units to move and press enter to select
- prettier!

<img width="1268" alt="screen shot 2017-10-24 at 8 32 27 am" src="https://user-images.githubusercontent.com/664341/31943335-708aa7f2-b896-11e7-8e8c-0e5828ce046b.png">

## To Do

- [x] Add a label like "Move how many?"
- [x] Add a "move half" button for easier splitting
- [x] [Escape] should close the modal

## Notes

I considered using [react-rangeslider](https://whoisandy.github.io/react-rangeslider/) but it didn't do some things I needed and did a bunch of stuff I didn't. A simple `<input type="range" />` was perfect! 🎉 

## Also

The "Winner" modal is now in the same place, using the same shared `.Modal` component:

<img width="1274" alt="screen shot 2017-10-24 at 8 34 16 am" src="https://user-images.githubusercontent.com/664341/31943367-85f22e4e-b896-11e7-99dd-59db188e01c8.png">

