### PR TITLE
Redirect to start a new game when the requested game is unavailible

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,1 +1,2 @@
+alias SengokuWeb.Router.Helpers, as: Routes
 alias Sengoku.{Game, Tile, Player, GameServer, Battle}

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -469,3 +469,11 @@ $tile-height: $tile-width * 1.1547005; // ratio of circumradius to inradius
   position: absolute;
   left: -9999px;
 }
+
+.alert {
+  color: #fff;
+  background-color: rgba(0,0,0,.1);
+  padding: .5em;
+  border-radius: .25em;
+  border: 1px solid rgba(0,0,0,.25);
+}

--- a/lib/sengoku/game_server.ex
+++ b/lib/sengoku/game_server.ex
@@ -33,6 +33,10 @@ defmodule Sengoku.GameServer do
 
   # API
 
+  def alive?(game_id) do
+    Registry.lookup(:game_server_registry, game_id) != []
+  end
+
   def authenticate_player(game_id, token, name \\ nil) do
     GenServer.call(via_tuple(game_id), {:authenticate_player, token, name})
   end

--- a/lib/sengoku_web/templates/layout/app.html.eex
+++ b/lib/sengoku_web/templates/layout/app.html.eex
@@ -1,5 +1,10 @@
 <main role="main" class="container">
-  <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
-  <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
+  <%= if get_flash(@conn, :info) do %>
+    <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
+  <% end %>
+  <%= if get_flash(@conn, :error) do %>
+    <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
+  <% end %>
+
   <%= @inner_content %>
 </main>

--- a/test/sengoku_web/live/game_live_test.exs
+++ b/test/sengoku_web/live/game_live_test.exs
@@ -3,6 +3,10 @@ defmodule SengokuWeb.GameLiveTest do
   import Phoenix.LiveViewTest
   @endpoint SengokuWeb.Endpoint
 
+  test "redirects when the GameServer is unavailable", %{conn: conn} do
+    assert {:error, {:redirect, %{to: "/"}}} = live(conn, "/game/no-game-here")
+  end
+
   test "connected mount", %{conn: conn} do
     {:ok, game_id} = Sengoku.GameServer.new(%{"board" => "japan"})
     {:ok, _view, html} = live(conn, "/game/#{game_id}")


### PR DESCRIPTION
<img width="1016" alt="Screen Shot 2020-05-24 at 9 39 00 AM" src="https://user-images.githubusercontent.com/664341/82755577-70be3d80-9da2-11ea-888b-5fbf346eeb53.png">

After a restart, or if the game crashes, a game's progress is lost. But at least we can help players start a new game in that case, instead of the current behavior, an unhelpful "Internal server error" message.