### PR TITLE
Add phoenix_live_dashboard behind basic auth in production

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Sengoku.Mixfile do
   def application do
     [
       mod: {Sengoku.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools, :os_mon]
     ]
   end
 


### PR DESCRIPTION
<img width="1216" alt="Screen Shot 2020-05-25 at 6 38 29 AM" src="https://user-images.githubusercontent.com/664341/82805654-59d72400-9e52-11ea-9867-29ee386f4e2b.png">
