### PR TITLE
Add instructions for before the game starts

### DIFF
--- a/lib/sengoku_web/live/game_live.ex
+++ b/lib/sengoku_web/live/game_live.ex
@@ -78,7 +78,7 @@ defmodule SengokuWeb.GameLive do
           </form>
         <% end %>
 
-        <%= if @game_state.turn == 0 do %>
+        <%= if @game_state.turn == 0 && @player_id do %>
           <button class="Button" phx-click="start">Start Game</button>
         <% end %>
 
@@ -108,20 +108,28 @@ defmodule SengokuWeb.GameLive do
           </ol>
         <% end %>
 
-        <%= if @game_state.turn > 0 && @game_state.current_player_id == @player_id && !@game_state.winner_id do %>
-          <p>
-            <%= cond do %>
-              <% @game_state.players[@game_state.current_player_id].unplaced_units > 0 -> %>
-                <%= "You have #{@game_state.players[@game_state.current_player_id].unplaced_units} units to place. Click on one of your territories to place a unit." %>
-              <% is_nil(@game_state.selected_tile_id) -> %>
-                Select one of your territories to attack or move from, or end your turn.
-              <% @game_state.tiles[@game_state.selected_tile_id].units == 1 -> %>
-                You must have more than 1 unit in a territory to move or attack.
-              <% true -> %>
-                Select an adjacent territory to attack or move into.
+        <p>
+          <%= if @game_state.turn == 0 do %>
+            <%= if @player_id do %>
+              You’re in! Share the URL with a friend to invite them, or start the game when ready.
+            <% else %>
+              You are currently spectating. Join the game or wait and watch.
             <% end %>
-          </p>
-        <% end %>
+          <% else %>
+            <%= if @game_state.current_player_id == @player_id && !@game_state.winner_id do %>
+              <%= cond do %>
+                <% @game_state.players[@game_state.current_player_id].unplaced_units > 0 -> %>
+                  <%= "You have #{@game_state.players[@game_state.current_player_id].unplaced_units} units to place. Click on one of your territories to place a unit." %>
+                <% is_nil(@game_state.selected_tile_id) -> %>
+                  Select one of your territories to attack or move from, or end your turn.
+                <% @game_state.tiles[@game_state.selected_tile_id].units == 1 -> %>
+                  You must have more than 1 unit in a territory to move or attack.
+                <% true -> %>
+                  Select an adjacent territory to attack or move into.
+              <% end %>
+            <% end %>
+          <% end %>
+        </p>
       </div>
 
       <div

--- a/test/sengoku_web/live/game_live_test.exs
+++ b/test/sengoku_web/live/game_live_test.exs
@@ -23,11 +23,15 @@ defmodule SengokuWeb.GameLiveTest do
     refute has_element?(view, ~s([phx-click="start_move"]))
     refute has_element?(view, ~s([phx-click="attack"]))
 
+    assert render(view) =~ "You are currently spectating. Join the game or wait and watch."
+    refute has_element?(view, ~s([phx-click="start"]))
+
     render_submit(view, :join, %{"player_name" => "Yojimbo"})
 
     assert has_element?(view, ".Player.player-bg-1", "Yojimbo")
+    assert render(view) =~ "You’re in! Share the URL with a friend to invite them, or start the game when ready."
 
-    render_click(view, :start)
+    render_click(element(view, ~s([phx-click="start"])))
 
     assert has_element?(view, ".player-bg-1 .Player-unplacedUnits", "3")
     assert render(view) =~ "You have 3 units to place"


### PR DESCRIPTION

<img width="1209" alt="Screen Shot 2020-05-26 at 6 19 23 AM" src="https://user-images.githubusercontent.com/664341/82889526-dd5b4880-9f18-11ea-98ea-1de2b540a1fc.png">


- Make it clear you’re spectating until you win
- Explain that you can share the URL to invite others
- Hide the “Start” button to spectators: only players who are in the game can start it