### PR TITLE
Run CI via Github Actions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,62 @@
+on: push
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        otp: [22.3]
+        elixir: [1.10.2]
+
+    services:
+      db:
+        image: postgres:12
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sengoku_test
+        ports: ['5432:5432']
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.0.0
+
+      - uses: actions/cache@v1
+        id: deps-cache
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+
+      - uses: actions/cache@v1
+        id: build-cache
+        with:
+          path: _build
+          key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+
+      - name: Find yarn cache location
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install deps
+        run: |
+          mix deps.get
+          (cd assets && yarn)
+
+      - run: mix format --check-formatted
+      - run: mix test

--- a/test/sengoku_web/live/game_live_test.exs
+++ b/test/sengoku_web/live/game_live_test.exs
@@ -29,7 +29,9 @@ defmodule SengokuWeb.GameLiveTest do
     render_submit(view, :join, %{"player_name" => "Yojimbo"})
 
     assert has_element?(view, ".Player.player-bg-1", "Yojimbo")
-    assert render(view) =~ "You’re in! Share the URL with a friend to invite them, or start the game when ready."
+
+    assert render(view) =~
+             "You’re in! Share the URL with a friend to invite them, or start the game when ready."
 
     render_click(element(view, ~s([phx-click="start"])))
 


### PR DESCRIPTION
## Why?

- Removing Codeship would mean one fewer tool 🎉 
- Paves the way for [automatic Gigalixir deployment](https://www.mitchellhanberg.com/ci-cd-with-phoenix-github-actions-and-gigalixir/)