### PR TITLE
Update game routes to match what `resources` does

### DIFF
--- a/lib/sengoku_web/controllers/game_controller.ex
+++ b/lib/sengoku_web/controllers/game_controller.ex
@@ -9,6 +9,6 @@ defmodule SengokuWeb.GameController do
 
   def create(conn, %{"board" => _board} = options) do
     {:ok, game_id} = GameServer.new(options)
-    redirect(conn, to: "/game/#{game_id}")
+    redirect(conn, to: Routes.live_path(conn, SengokuWeb.GameLive, game_id))
   end
 end

--- a/lib/sengoku_web/router.ex
+++ b/lib/sengoku_web/router.ex
@@ -28,8 +28,8 @@ defmodule SengokuWeb.Router do
     pipe_through :browser
 
     get "/", GameController, :new
-    post "/", GameController, :create
-    live "/game/:game_id", GameLive, layout: {SengokuWeb.LayoutView, :game}
+    post "/games", GameController, :create
+    live "/games/:game_id", GameLive, layout: {SengokuWeb.LayoutView, :game}
   end
 
   scope "/" do

--- a/lib/sengoku_web/templates/game/new.html.eex
+++ b/lib/sengoku_web/templates/game/new.html.eex
@@ -13,7 +13,7 @@
     </ul>
   </section>
 
-  <%= form_tag("/") do %>
+  <%= form_tag(Routes.game_path(@conn, :create)) do %>
     <h2>Map</h2>
     <p>
       <input class="BorderRadio-input" id="board_japan" type="radio" name="board" value="japan" checked />

--- a/test/sengoku_web/live/game_live_test.exs
+++ b/test/sengoku_web/live/game_live_test.exs
@@ -4,18 +4,18 @@ defmodule SengokuWeb.GameLiveTest do
   @endpoint SengokuWeb.Endpoint
 
   test "redirects when the GameServer is unavailable", %{conn: conn} do
-    assert {:error, {:redirect, %{to: "/"}}} = live(conn, "/game/no-game-here")
+    assert {:error, {:redirect, %{to: "/"}}} = live(conn, "/games/no-game-here")
   end
 
   test "connected mount", %{conn: conn} do
     {:ok, game_id} = Sengoku.GameServer.new(%{"board" => "japan"})
-    {:ok, _view, html} = live(conn, "/game/#{game_id}")
+    {:ok, _view, html} = live(conn, live_path(conn, SengokuWeb.GameLive, game_id))
     assert html =~ ~s(<div class="Game">)
   end
 
   test "joining and playing a game", %{conn: conn} do
     {:ok, game_id} = Sengoku.GameServer.new(%{"board" => "japan"})
-    {:ok, view, _html} = live(conn, "/game/#{game_id}")
+    {:ok, view, _html} = live(conn, live_path(conn, SengokuWeb.GameLive, game_id))
 
     # Ensure nothing on the board is interactive before the game starts
     refute has_element?(view, ~s([phx-click="place_unit"]))
@@ -69,7 +69,7 @@ defmodule SengokuWeb.GameLiveTest do
 
   test "the Region Bonuses module", %{conn: conn} do
     {:ok, game_id} = Sengoku.GameServer.new(%{"board" => "japan"})
-    {:ok, view, html} = live(conn, "/game/#{game_id}")
+    {:ok, view, html} = live(conn, live_path(conn, SengokuWeb.GameLive, game_id))
 
     assert html =~ "Region Bonuses"
 


### PR DESCRIPTION
And use routing helpers where possible. Just for convenience/consistency.