### PR TITLE
Provide a way to cancel a move

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -476,6 +476,7 @@ $tile-height: $tile-width * 1.1547005; // ratio of circumradius to inradius
     flex-direction: row-reverse;
 
     & > * {
+      white-space: nowrap;
       margin-right: 1em;
 
       &:first-child {

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -202,23 +202,34 @@ $tile-height: $tile-width * 1.1547005; // ratio of circumradius to inradius
     overflow: visible;
   }
 
-  &:hover {
-    transform: scale(1.1);
-  }
-
   &--selected {
     stroke: rgba(255,255,255,.5);
     stroke-width: 15px;
     paint-order: stroke;
   }
 
-  &--potentialMoveTarget {
+  &[phx-click="place_unit"],
+  &[phx-click="select_tile"] {
+    cursor: pointer;
+
+    svg {
+      stroke: rgba(255,255,255,.25);
+      stroke-width: 15px;
+      paint-order: stroke;
+    }
+
+    &:hover {
+      transform: scale(1.1);
+    }
+  }
+
+  &[phx-click="start_move"] {
     svg {
       filter: drop-shadow(0 0 3px rgba(255, 255, 255, .75)) drop-shadow(0 0 5px rgba(0, 128, 0, 1));
     }
   }
 
-  &--potentialAttackTarget {
+  &[phx-click="attack"] {
     svg {
       filter: drop-shadow(0 0 3px rgba(255, 255, 255, .75)) drop-shadow(0 0 5px rgba(255, 0, 0, 1));
     }

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -8,6 +8,15 @@ $red: #cc241d;
 $z-index-overlay: 10;
 $z-index-logo: 100;
 
+$player-1-color: #fb4934;
+$player-2-color: #b8bb26;
+$player-3-color: #fabd2f;
+$player-4-color: #458588;
+$player-5-color: #d3869b;
+$player-6-color: #fe8019;
+$player-7-color: #8ec07c;
+$player-8-color: #3c3836;
+
 * {
   box-sizing: border-box;
 }
@@ -258,14 +267,14 @@ $tile-height: $tile-width * 1.1547005; // ratio of circumradius to inradius
   user-select: none;
 }
 
-.player-bg-1 { background-color: #fb4934; }
-.player-bg-2 { background-color: #b8bb26; }
-.player-bg-3 { background-color: #fabd2f; }
-.player-bg-4 { background-color: #458588; }
-.player-bg-5 { background-color: #d3869b; }
-.player-bg-6 { background-color: #fe8019; }
-.player-bg-7 { background-color: #8ec07c; }
-.player-bg-8 { background-color: #3c3836; }
+.player-bg-1 { background-color: $player-1-color; }
+.player-bg-2 { background-color: $player-2-color; }
+.player-bg-3 { background-color: $player-3-color; }
+.player-bg-4 { background-color: $player-4-color; }
+.player-bg-5 { background-color: $player-5-color; }
+.player-bg-6 { background-color: $player-6-color; }
+.player-bg-7 { background-color: $player-7-color; }
+.player-bg-8 { background-color: $player-8-color; }
 
 .region-1 svg { fill: #493829; }
 .region-2 svg { fill: #816c5b; }
@@ -278,14 +287,14 @@ $tile-height: $tile-width * 1.1547005; // ratio of circumradius to inradius
 .region-9 svg { fill: #855723; }
 .region-10 svg { fill: #eae2b7; }
 
-.region-ownedby-1 svg { stroke: #fb4934; }
-.region-ownedby-2 svg { stroke: #b8bb26; }
-.region-ownedby-3 svg { stroke: #fabd2f; }
-.region-ownedby-4 svg { stroke: #458588; }
-.region-ownedby-5 svg { stroke: #d3869b; }
-.region-ownedby-6 svg { stroke: #fe8019; }
-.region-ownedby-7 svg { stroke: #8ec07c; }
-.region-ownedby-8 svg { stroke: #3c3836; }
+.region-ownedby-1 svg { stroke: $player-1-color; }
+.region-ownedby-2 svg { stroke: $player-2-color; }
+.region-ownedby-3 svg { stroke: $player-3-color; }
+.region-ownedby-4 svg { stroke: $player-4-color; }
+.region-ownedby-5 svg { stroke: $player-5-color; }
+.region-ownedby-6 svg { stroke: $player-6-color; }
+.region-ownedby-7 svg { stroke: $player-7-color; }
+.region-ownedby-8 svg { stroke: $player-8-color; }
 
 .Regions {
   list-style: none;

--- a/lib/sengoku/ai/random.ex
+++ b/lib/sengoku/ai/random.ex
@@ -11,7 +11,7 @@ defmodule Sengoku.AI.Random do
   def take_action(state) do
     cond do
       has_unplaced_units?(state) -> place_unit(state)
-      has_required_move?(state) -> make_required_move(state)
+      has_pending_move?(state) -> make_pending_move(state)
       has_attackable_neighbor?(state) -> attack(state)
       can_move?(state) -> move(state)
       true -> end_turn()
@@ -31,16 +31,16 @@ defmodule Sengoku.AI.Random do
     %{type: "place_unit", tile_id: tile_id}
   end
 
-  defp has_required_move?(state) do
-    not is_nil(state.required_move)
+  defp has_pending_move?(state) do
+    not is_nil(state.pending_move)
   end
 
-  defp make_required_move(%{required_move: required_move}) do
+  defp make_pending_move(%{pending_move: pending_move}) do
     %{
       type: "move",
-      from_id: required_move.from_id,
-      to_id: required_move.to_id,
-      count: Enum.random(required_move.min..required_move.max)
+      from_id: pending_move.from_id,
+      to_id: pending_move.to_id,
+      count: Enum.random(pending_move.min..pending_move.max)
     }
   end
 

--- a/lib/sengoku/ai/smart.ex
+++ b/lib/sengoku/ai/smart.ex
@@ -10,7 +10,7 @@ defmodule Sengoku.AI.Smart do
   def take_action(state) do
     cond do
       has_unplaced_units?(state) -> place_unit(state)
-      has_required_move?(state) -> make_required_move(state)
+      has_pending_move?(state) -> make_pending_move(state)
       has_attackable_neighbor?(state) -> attack(state)
       can_move?(state) -> move(state)
       true -> end_turn()
@@ -33,16 +33,16 @@ defmodule Sengoku.AI.Smart do
     %{type: "place_unit", tile_id: tile_id}
   end
 
-  defp has_required_move?(state) do
-    not is_nil(state.required_move)
+  defp has_pending_move?(state) do
+    not is_nil(state.pending_move)
   end
 
-  defp make_required_move(%{required_move: required_move}) do
+  defp make_pending_move(%{pending_move: pending_move}) do
     %{
       type: "move",
-      from_id: required_move.from_id,
-      to_id: required_move.to_id,
-      count: required_move.max
+      from_id: pending_move.from_id,
+      to_id: pending_move.to_id,
+      count: pending_move.max
     }
   end
 

--- a/lib/sengoku/game.ex
+++ b/lib/sengoku/game.ex
@@ -234,12 +234,11 @@ defmodule Sengoku.Game do
       to_id: to_id,
       min: 1,
       max: state.tiles[from_id].units - 1,
-      required: false,
-      end_turn: true
+      required: false
     })
   end
 
-  def move(%{pending_move: %{end_turn: move_ends_turn}} = state, from_id, to_id, count) do
+  def move(%{pending_move: %{required: required}} = state, from_id, to_id, count) do
     if from_id == state.pending_move.from_id and to_id == state.pending_move.to_id and
          count >= state.pending_move.min do
 
@@ -248,7 +247,7 @@ defmodule Sengoku.Game do
       |> Tile.adjust_units(to_id, count)
       |> Map.put(:pending_move, nil)
       |> Map.put(:selected_tile_id, nil)
-      |> maybe_end_turn(move_ends_turn)
+      |> end_turn_unless_required_move(required)
     else
       Logger.info("Invalid move of `#{count}` units from `#{from_id}` to `#{to_id}`")
       state
@@ -275,6 +274,9 @@ defmodule Sengoku.Game do
     end
   end
 
+  defp end_turn_unless_required_move(state, false), do: end_turn(state)
+  defp end_turn_unless_required_move(state, true), do: state
+
   def cancel_move(%{pending_move: nil} = state) do
     state
   end
@@ -286,9 +288,6 @@ defmodule Sengoku.Game do
     |> Map.put(:selected_tile_id, nil)
     |> Map.put(:pending_move, nil)
   end
-
-  defp maybe_end_turn(state, true), do: end_turn(state)
-  defp maybe_end_turn(state, _), do: state
 
   defp increment_turn(state) do
     state

--- a/lib/sengoku/game.ex
+++ b/lib/sengoku/game.ex
@@ -241,7 +241,6 @@ defmodule Sengoku.Game do
   def move(%{pending_move: %{required: required}} = state, from_id, to_id, count) do
     if from_id == state.pending_move.from_id and to_id == state.pending_move.to_id and
          count >= state.pending_move.min do
-
       state
       |> Tile.adjust_units(from_id, -count)
       |> Tile.adjust_units(to_id, count)
@@ -280,9 +279,11 @@ defmodule Sengoku.Game do
   def cancel_move(%{pending_move: nil} = state) do
     state
   end
+
   def cancel_move(%{pending_move: %{required: true}} = state) do
     state
   end
+
   def cancel_move(state) do
     state
     |> Map.put(:selected_tile_id, nil)

--- a/lib/sengoku/game.ex
+++ b/lib/sengoku/game.ex
@@ -229,7 +229,7 @@ defmodule Sengoku.Game do
     |> Map.put(:required_move, %{
       from_id: from_id,
       to_id: to_id,
-      min: 0,
+      min: 1,
       max: state.tiles[from_id].units - 1
     })
   end

--- a/lib/sengoku/game.ex
+++ b/lib/sengoku/game.ex
@@ -61,6 +61,10 @@ defmodule Sengoku.Game do
     move(state, from_id, to_id, count)
   end
 
+  def handle_action(state, %{type: "cancel_move"}) do
+    cancel_move(state)
+  end
+
   def handle_action(state, action) do
     Logger.info("Unrecognized action `#{inspect(action)}`")
     state
@@ -209,7 +213,8 @@ defmodule Sengoku.Game do
           from_id: from_id,
           to_id: to_id,
           min: 3,
-          max: movable_units
+          max: movable_units,
+          required: true
         })
       else
         state
@@ -230,7 +235,8 @@ defmodule Sengoku.Game do
       from_id: from_id,
       to_id: to_id,
       min: 1,
-      max: state.tiles[from_id].units - 1
+      max: state.tiles[from_id].units - 1,
+      required: false
     })
   end
 
@@ -267,6 +273,19 @@ defmodule Sengoku.Game do
       Logger.info("Invalid move of `#{count}` units from `#{from_id}` to `#{to_id}`")
       state
     end
+  end
+
+  def cancel_move(%{pending_move: nil} = state) do
+    state
+  end
+  def cancel_move(%{pending_move: %{required: true}} = state) do
+    state
+  end
+  def cancel_move(state) do
+    state
+    |> Map.put(:selected_tile_id, nil)
+    |> Map.put(:end_turn_after_move, false)
+    |> Map.put(:pending_move, nil)
   end
 
   defp maybe_end_turn(%{end_turn_after_move: true} = state) do

--- a/lib/sengoku_web/live/game_live.ex
+++ b/lib/sengoku_web/live/game_live.ex
@@ -151,11 +151,11 @@ defmodule SengokuWeb.GameLive do
                 <%= if id == @game_state.selected_tile_id, do: "Tile--selected" %>
               "
               id="tile_<%= id %>"
-              <%= if @player_id && @player_id == @game_state.current_player_id do %>
+              <%= if @player_id && @game_state.current_player_id && @player_id == @game_state.current_player_id do %>
                 <%= cond do %>
-                  <% @game_state.current_player_id && @game_state.players[@game_state.current_player_id].unplaced_units > 0 && @game_state.tiles[id].owner == @game_state.current_player_id -> %>
+                  <% @game_state.players[@game_state.current_player_id].unplaced_units > 0 && @game_state.tiles[id].owner == @game_state.current_player_id -> %>
                     phx-click="place_unit"
-                  <% is_nil(@game_state.selected_tile_id) && @game_state.current_player_id && @game_state.tiles[id].units > 1 && @game_state.tiles[id].owner == @game_state.current_player_id -> %>
+                  <% is_nil(@game_state.selected_tile_id) && @game_state.tiles[id].units > 1 && @game_state.tiles[id].owner == @game_state.current_player_id -> %>
                     phx-click="select_tile"
                   <% @game_state.selected_tile_id && id in @game_state.tiles[@game_state.selected_tile_id].neighbors -> %>
                     <%= if @game_state.tiles[id].owner == @game_state.current_player_id do %>

--- a/lib/sengoku_web/live/game_live.ex
+++ b/lib/sengoku_web/live/game_live.ex
@@ -292,6 +292,14 @@ defmodule SengokuWeb.GameLive do
     {:noreply, socket}
   end
 
+  @impl Phoenix.LiveView
+  def handle_event("cancel_move", _params, socket) do
+    %{game_id: game_id, player_id: player_id} = socket.assigns
+    GameServer.action(game_id, player_id, %{type: "cancel_move"})
+
+    {:noreply, socket}
+  end
+
   defp owner_of_region(region, tiles) do
     region.tile_ids
     |> Enum.map(fn tile_id ->

--- a/lib/sengoku_web/live/game_live.ex
+++ b/lib/sengoku_web/live/game_live.ex
@@ -6,7 +6,7 @@ defmodule SengokuWeb.GameLive do
   alias Sengoku.GameServer
   alias SengokuWeb.MoveUnitsForm
 
-  @impl true
+  @impl Phoenix.LiveView
   def mount(%{"game_id" => game_id}, %{"anonymous_user_id" => user_token}, socket) do
     if GameServer.alive?(game_id) do
       game_state = GameServer.get_state(game_id)
@@ -30,7 +30,7 @@ defmodule SengokuWeb.GameLive do
     end
   end
 
-  @impl true
+  @impl Phoenix.LiveView
   def render(assigns) do
     ~L"""
     <div class="Game">
@@ -185,12 +185,12 @@ defmodule SengokuWeb.GameLive do
     """
   end
 
-  @impl true
+  @impl Phoenix.LiveView
   def handle_info({:game_updated, new_state}, socket) do
     {:noreply, assign(socket, game_state: new_state)}
   end
 
-  @impl true
+  @impl Phoenix.LiveView
   def handle_event("join", %{"player_name" => player_name}, socket) do
     case GameServer.authenticate_player(
            socket.assigns.game_id,
@@ -206,7 +206,7 @@ defmodule SengokuWeb.GameLive do
     end
   end
 
-  @impl true
+  @impl Phoenix.LiveView
   def handle_event("start", _params, socket) do
     %{game_id: game_id, player_id: player_id} = socket.assigns
     GameServer.action(game_id, player_id, %{type: "start_game"})
@@ -214,7 +214,7 @@ defmodule SengokuWeb.GameLive do
     {:noreply, socket}
   end
 
-  @impl true
+  @impl Phoenix.LiveView
   def handle_event("place_unit", %{"tile_id" => tile_id_string}, socket) do
     {tile_id, _} = Integer.parse(tile_id_string)
     %{game_id: game_id, player_id: player_id} = socket.assigns
@@ -223,7 +223,7 @@ defmodule SengokuWeb.GameLive do
     {:noreply, socket}
   end
 
-  @impl true
+  @impl Phoenix.LiveView
   def handle_event("end_turn", _params, socket) do
     %{game_id: game_id, player_id: player_id} = socket.assigns
     GameServer.action(game_id, player_id, %{type: "end_turn"})
@@ -231,7 +231,7 @@ defmodule SengokuWeb.GameLive do
     {:noreply, socket}
   end
 
-  @impl true
+  @impl Phoenix.LiveView
   def handle_event("select_tile", %{"tile_id" => tile_id_string}, socket) do
     {tile_id, _} = Integer.parse(tile_id_string)
     %{game_id: game_id, player_id: player_id} = socket.assigns
@@ -240,7 +240,7 @@ defmodule SengokuWeb.GameLive do
     {:noreply, socket}
   end
 
-  @impl true
+  @impl Phoenix.LiveView
   def handle_event("unselect_tile", _params, socket) do
     %{game_id: game_id, player_id: player_id} = socket.assigns
     GameServer.action(game_id, player_id, %{type: "unselect_tile"})
@@ -248,7 +248,7 @@ defmodule SengokuWeb.GameLive do
     {:noreply, socket}
   end
 
-  @impl true
+  @impl Phoenix.LiveView
   def handle_event("attack", %{"tile_id" => tile_id_string}, socket) do
     {tile_id, _} = Integer.parse(tile_id_string)
 
@@ -264,7 +264,7 @@ defmodule SengokuWeb.GameLive do
     {:noreply, socket}
   end
 
-  @impl true
+  @impl Phoenix.LiveView
   def handle_event("start_move", %{"tile_id" => tile_id_string}, socket) do
     {to_tile_id, _} = Integer.parse(tile_id_string)
 
@@ -280,7 +280,7 @@ defmodule SengokuWeb.GameLive do
     {:noreply, socket}
   end
 
-  @impl true
+  @impl Phoenix.LiveView
   def handle_event("move", %{"count" => count_string}, socket) do
     {count, _} = Integer.parse(count_string)
 

--- a/lib/sengoku_web/live/game_live.ex
+++ b/lib/sengoku_web/live/game_live.ex
@@ -139,8 +139,8 @@ defmodule SengokuWeb.GameLive do
         class="Board"
         <%= if @game_state.selected_tile_id, do: "phx-click=unselect_tile" %>
       >
-        <%= if @game_state.required_move && is_nil(@game_state.winner_id) && @game_state.current_player_id == @player_id do %>
-          <%= live_component(@socket, MoveUnitsForm, id: "move_form", required_move: @game_state.required_move) %>
+        <%= if @game_state.pending_move && is_nil(@game_state.winner_id) && @game_state.current_player_id == @player_id do %>
+          <%= live_component(@socket, MoveUnitsForm, id: "move_form", pending_move: @game_state.pending_move) %>
         <% end %>
         <ul class="Tiles">
           <%= for {id, tile} <- @game_state.tiles do %>
@@ -279,13 +279,13 @@ defmodule SengokuWeb.GameLive do
   def handle_event("move", %{"count" => count_string}, socket) do
     {count, _} = Integer.parse(count_string)
 
-    %{game_id: game_id, player_id: player_id, game_state: %{required_move: required_move}} =
+    %{game_id: game_id, player_id: player_id, game_state: %{pending_move: pending_move}} =
       socket.assigns
 
     GameServer.action(game_id, player_id, %{
       type: "move",
-      from_id: required_move.from_id,
-      to_id: required_move.to_id,
+      from_id: pending_move.from_id,
+      to_id: pending_move.to_id,
       count: count
     })
 

--- a/lib/sengoku_web/live/game_live.ex
+++ b/lib/sengoku_web/live/game_live.ex
@@ -149,27 +149,22 @@ defmodule SengokuWeb.GameLive do
                 Tile
                 <%= "region-#{elem(Enum.find(@game_state.regions, fn({_id, region}) -> id in region.tile_ids end), 0)}" %>
                 <%= if id == @game_state.selected_tile_id, do: "Tile--selected" %>
-                <%= if @game_state.selected_tile_id && id in @game_state.tiles[@game_state.selected_tile_id].neighbors do %>
-                  <%= if @game_state.tiles[id].owner == @game_state.current_player_id do %>
-                    Tile--potentialMoveTarget
-                  <% else %>
-                    Tile--potentialAttackTarget
-                  <% end %>
-                <% end %>
               "
               id="tile_<%= id %>"
-              <%= cond do %>
-                <% @game_state.current_player_id && @game_state.players[@game_state.current_player_id].unplaced_units > 0 && @game_state.tiles[id].owner == @game_state.current_player_id -> %>
-                  phx-click="place_unit"
-                <% is_nil(@game_state.selected_tile_id) && @game_state.current_player_id && @game_state.tiles[id].owner == @game_state.current_player_id -> %>
-                  phx-click="select_tile"
-                <% @game_state.selected_tile_id && id in @game_state.tiles[@game_state.selected_tile_id].neighbors -> %>
-                  <%= if @game_state.tiles[id].owner == @game_state.current_player_id do %>
-                    phx-click="start_move"
-                  <% else %>
-                    phx-click="attack"
-                  <% end %>
-                <% true -> %>
+              <%= if @player_id && @player_id == @game_state.current_player_id do %>
+                <%= cond do %>
+                  <% @game_state.current_player_id && @game_state.players[@game_state.current_player_id].unplaced_units > 0 && @game_state.tiles[id].owner == @game_state.current_player_id -> %>
+                    phx-click="place_unit"
+                  <% is_nil(@game_state.selected_tile_id) && @game_state.current_player_id && @game_state.tiles[id].units > 1 && @game_state.tiles[id].owner == @game_state.current_player_id -> %>
+                    phx-click="select_tile"
+                  <% @game_state.selected_tile_id && id in @game_state.tiles[@game_state.selected_tile_id].neighbors -> %>
+                    <%= if @game_state.tiles[id].owner == @game_state.current_player_id do %>
+                      phx-click="start_move"
+                    <% else %>
+                      phx-click="attack"
+                    <% end %>
+                  <% true -> %>
+                <% end %>
               <% end %>
               phx-value-tile_id="<%= id %>"
             >

--- a/lib/sengoku_web/live/move_units_form.ex
+++ b/lib/sengoku_web/live/move_units_form.ex
@@ -13,7 +13,7 @@ defmodule SengokuWeb.MoveUnitsForm do
     <div class="Modal">
       <div class="MoveForm">
         <h2>Move how many?</h2>
-        <form
+        <div
           class="MoveForm-slider"
           phx-change="update_count"
           phx-target="<%= @myself %>"
@@ -28,7 +28,7 @@ defmodule SengokuWeb.MoveUnitsForm do
                  autofocus
           />
           <span><%= @pending_move.max %></span>
-        </form>
+        </div>
         <div class="MoveForm-actions">
           <button
             class="Button Button--primary"

--- a/lib/sengoku_web/live/move_units_form.ex
+++ b/lib/sengoku_web/live/move_units_form.ex
@@ -2,7 +2,7 @@ defmodule SengokuWeb.MoveUnitsForm do
   use Phoenix.LiveComponent
 
   @impl true
-  def update(%{required_move: %{min: min, max: max}} = assigns, socket) do
+  def update(%{pending_move: %{min: min, max: max}} = assigns, socket) do
     default_count = midpoint(min, max)
     {:ok, assign(socket, Map.merge(assigns, %{count: default_count}))}
   end
@@ -18,23 +18,23 @@ defmodule SengokuWeb.MoveUnitsForm do
           phx-change="update_count"
           phx-target="<%= @myself %>"
         >
-          <span><%= @required_move.min %></span>
+          <span><%= @pending_move.min %></span>
           <input class="MoveForm-input"
                  type="range"
-                 min=<%= @required_move.min %>
-                 max=<%= @required_move.max %>
+                 min=<%= @pending_move.min %>
+                 max=<%= @pending_move.max %>
                  name="count"
                  value="<%= @count %>"
                  autofocus
           />
-          <span><%= @required_move.max %></span>
+          <span><%= @pending_move.max %></span>
         </form>
         <div class="MoveForm-actions">
           <button
             class="Button Button--primary"
             phx-click="move"
-            phx-value-count="<%= @required_move.max %>"
-          >Move Max (<%= @required_move.max %>)</button>
+            phx-value-count="<%= @pending_move.max %>"
+          >Move Max (<%= @pending_move.max %>)</button>
           <button
             class="Button Button--primary"
             phx-click="move"
@@ -43,8 +43,8 @@ defmodule SengokuWeb.MoveUnitsForm do
           <button
             class="Button Button--primary"
             phx-click="move"
-            phx-value-count="<%= @required_move.min %>"
-          >Move Min (<%= @required_move.min %>)</button>
+            phx-value-count="<%= @pending_move.min %>"
+          >Move Min (<%= @pending_move.min %>)</button>
         </div>
       </div>
     </div>

--- a/lib/sengoku_web/live/move_units_form.ex
+++ b/lib/sengoku_web/live/move_units_form.ex
@@ -45,6 +45,12 @@ defmodule SengokuWeb.MoveUnitsForm do
             phx-click="move"
             phx-value-count="<%= @pending_move.min %>"
           >Move Min (<%= @pending_move.min %>)</button>
+          <%= unless @pending_move.required do %>
+            <button
+              class="Button"
+              phx-click="cancel_move"
+            >Cancel</button>
+          <% end %>
         </div>
       </div>
     </div>

--- a/lib/sengoku_web/live/move_units_form.ex
+++ b/lib/sengoku_web/live/move_units_form.ex
@@ -2,8 +2,8 @@ defmodule SengokuWeb.MoveUnitsForm do
   use Phoenix.LiveComponent
 
   @impl true
-  def update(assigns, socket) do
-    default_count = max(assigns.required_move.min, floor(assigns.required_move.max / 2))
+  def update(%{required_move: %{min: min, max: max}} = assigns, socket) do
+    default_count = midpoint(min, max)
     {:ok, assign(socket, Map.merge(assigns, %{count: default_count}))}
   end
 
@@ -55,5 +55,9 @@ defmodule SengokuWeb.MoveUnitsForm do
   def handle_event("update_count", %{"count" => count_string}, socket) do
     {count, _} = Integer.parse(count_string)
     {:noreply, assign(socket, count: count)}
+  end
+
+  defp midpoint(low, high) do
+    low + floor((high - low) / 2)
   end
 end

--- a/lib/sengoku_web/live/move_units_form.ex
+++ b/lib/sengoku_web/live/move_units_form.ex
@@ -25,7 +25,7 @@ defmodule SengokuWeb.MoveUnitsForm do
                  max=<%= @required_move.max %>
                  name="count"
                  value="<%= @count %>"
-                 autoFocus
+                 autofocus
           />
           <span><%= @required_move.max %></span>
         </form>

--- a/test/sengoku/ai/random_test.exs
+++ b/test/sengoku/ai/random_test.exs
@@ -14,7 +14,7 @@ defmodule Sengoku.AI.RandomTest do
         1 => %Tile{owner: 1, units: 1, neighbors: [2]},
         2 => %Tile{owner: nil, units: 1, neighbors: [1]}
       },
-      required_move: nil
+      pending_move: nil
     }
 
     action = AI.Random.take_action(state)
@@ -33,7 +33,7 @@ defmodule Sengoku.AI.RandomTest do
         1 => %Tile{owner: 1, units: 2, neighbors: [2]},
         2 => %Tile{owner: nil, units: 1, neighbors: [1]}
       },
-      required_move: nil
+      pending_move: nil
     }
 
     action = AI.Random.take_action(state)
@@ -53,7 +53,7 @@ defmodule Sengoku.AI.RandomTest do
         2 => %Tile{owner: 1, units: 1, neighbors: [1, 3]},
         3 => %Tile{owner: 2, units: 1, neighbors: [2]}
       },
-      required_move: nil
+      pending_move: nil
     }
 
     action = AI.Random.take_action(state)
@@ -78,7 +78,7 @@ defmodule Sengoku.AI.RandomTest do
         2 => %Tile{owner: 1, units: 5, neighbors: [1, 3]},
         3 => %Tile{owner: 2, units: 1, neighbors: [2]}
       },
-      required_move: %{
+      pending_move: %{
         from_id: 2,
         to_id: 1,
         min: 3,
@@ -107,7 +107,7 @@ defmodule Sengoku.AI.RandomTest do
         1 => %Tile{owner: 1, units: 1, neighbors: [2]},
         2 => %Tile{owner: nil, units: 1, neighbors: [1]}
       },
-      required_move: nil
+      pending_move: nil
     }
 
     action = AI.Random.take_action(state)

--- a/test/sengoku/ai/smart_test.exs
+++ b/test/sengoku/ai/smart_test.exs
@@ -18,7 +18,7 @@ defmodule Sengoku.AI.SmartTest do
         1 => %Region{value: 1, tile_ids: [1]},
         2 => %Region{value: 1, tile_ids: [2]}
       },
-      required_move: nil
+      pending_move: nil
     }
 
     action = AI.Smart.take_action(state)
@@ -41,7 +41,7 @@ defmodule Sengoku.AI.SmartTest do
         1 => %Region{value: 1, tile_ids: [1]},
         2 => %Region{value: 1, tile_ids: [2]}
       },
-      required_move: nil
+      pending_move: nil
     }
 
     action = AI.Smart.take_action(state)
@@ -61,7 +61,7 @@ defmodule Sengoku.AI.SmartTest do
         2 => %Tile{owner: 1, units: 1, neighbors: [1, 3]},
         3 => %Tile{owner: 2, units: 1, neighbors: [2]}
       },
-      required_move: nil
+      pending_move: nil
     }
 
     action = AI.Smart.take_action(state)
@@ -86,7 +86,7 @@ defmodule Sengoku.AI.SmartTest do
         2 => %Tile{owner: 1, units: 5, neighbors: [1, 3]},
         3 => %Tile{owner: 2, units: 1, neighbors: [2]}
       },
-      required_move: %{
+      pending_move: %{
         from_id: 2,
         to_id: 1,
         min: 3,
@@ -115,7 +115,7 @@ defmodule Sengoku.AI.SmartTest do
         1 => %Tile{owner: 1, units: 1, neighbors: [2]},
         2 => %Tile{owner: nil, units: 1, neighbors: [1]}
       },
-      required_move: nil
+      pending_move: nil
     }
 
     action = AI.Smart.take_action(state)

--- a/test/sengoku/game_test.exs
+++ b/test/sengoku/game_test.exs
@@ -534,7 +534,7 @@ defmodule Sengoku.GameTest do
       assert new_state.required_move == %{
                from_id: 1,
                to_id: 2,
-               min: 0,
+               min: 1,
                max: 2
              }
 

--- a/test/sengoku/game_test.exs
+++ b/test/sengoku/game_test.exs
@@ -519,7 +519,6 @@ defmodule Sengoku.GameTest do
       old_state = %{
         selected_tile_id: 1,
         pending_move: nil,
-        end_turn_after_move: false,
         players: %{
           1 => %Player{active: true},
           2 => %Player{active: true}
@@ -537,10 +536,9 @@ defmodule Sengoku.GameTest do
                to_id: 2,
                min: 1,
                max: 2,
-               required: false
+               required: false,
+               end_turn: true
              }
-
-      assert new_state.end_turn_after_move
     end
   end
 
@@ -557,12 +555,7 @@ defmodule Sengoku.GameTest do
           1 => %Player{active: true, unplaced_units: 0},
           2 => %Player{active: true, unplaced_units: 0}
         },
-        pending_move: %{
-          from_id: 1,
-          to_id: 2,
-          min: 3,
-          max: 4
-        }
+        pending_move: nil
       }
 
       new_state = Game.move(old_state, 1, 2, 4)
@@ -572,7 +565,7 @@ defmodule Sengoku.GameTest do
       assert new_state.selected_tile_id == nil
     end
 
-    test "ends the Player’s turn when end_turn_after_move is true" do
+    test "ends the Player’s turn when pending_move.end_turn is true" do
       old_state = %{
         current_player_id: 1,
         tiles: %{
@@ -587,9 +580,10 @@ defmodule Sengoku.GameTest do
           from_id: 1,
           to_id: 2,
           min: 3,
-          max: 4
-        },
-        end_turn_after_move: true
+          max: 4,
+          required: false,
+          end_turn: true
+        }
       }
 
       new_state = Game.move(old_state, 1, 2, 3)
@@ -719,7 +713,9 @@ defmodule Sengoku.GameTest do
           from_id: 1,
           to_id: 2,
           min: 3,
-          max: 4
+          max: 4,
+          required: true,
+          end_turn: false
         }
       }
 
@@ -746,7 +742,9 @@ defmodule Sengoku.GameTest do
           from_id: 1,
           to_id: 2,
           min: 3,
-          max: 4
+          max: 4,
+          required: true,
+          end_turn: false
         }
       }
 
@@ -770,7 +768,9 @@ defmodule Sengoku.GameTest do
           from_id: 1,
           to_id: 2,
           min: 3,
-          max: 4
+          max: 4,
+          required: true,
+          end_turn: false
         }
       }
 
@@ -794,7 +794,9 @@ defmodule Sengoku.GameTest do
           from_id: 1,
           to_id: 2,
           min: 3,
-          max: 4
+          max: 4,
+          required: true,
+          end_turn: false
         }
       }
 
@@ -808,16 +810,15 @@ defmodule Sengoku.GameTest do
       old_state = %{
         current_player_id: 1,
         selected_tile_id: 1,
-        end_turn_after_move: true,
         pending_move: %{
-          required: false
+          required: false,
+          end_turn: true
         }
       }
 
       new_state = Game.cancel_move(old_state)
 
       assert is_nil(new_state.pending_move)
-      refute new_state.end_turn_after_move
       assert old_state.current_player_id == new_state.current_player_id
       assert is_nil(new_state.selected_tile_id)
     end
@@ -826,7 +827,6 @@ defmodule Sengoku.GameTest do
       old_state = %{
         current_player_id: 1,
         selected_tile_id: 1,
-        end_turn_after_move: true,
         pending_move: nil
       }
 
@@ -839,9 +839,9 @@ defmodule Sengoku.GameTest do
       old_state = %{
         current_player_id: 1,
         selected_tile_id: 1,
-        end_turn_after_move: true,
         pending_move: %{
-          required: true
+          required: true,
+          end_turn: false
         }
       }
 

--- a/test/sengoku/game_test.exs
+++ b/test/sengoku/game_test.exs
@@ -238,7 +238,7 @@ defmodule Sengoku.GameTest do
           4 => %Player{unplaced_units: 1, active: true}
         },
         tiles: %{},
-        required_move:
+        pending_move:
           %{
             # Not nil
           }
@@ -260,7 +260,7 @@ defmodule Sengoku.GameTest do
         tiles: %{
           1 => %Tile{owner: 1, units: 4}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = old_state |> Game.place_unit(1)
@@ -278,7 +278,7 @@ defmodule Sengoku.GameTest do
         tiles: %{
           1 => %Tile{owner: 99, units: 4}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = old_state |> Game.place_unit(1)
@@ -295,7 +295,7 @@ defmodule Sengoku.GameTest do
         tiles: %{
           1 => %Tile{owner: 1, units: 4}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = old_state |> Game.place_unit(1)
@@ -303,7 +303,7 @@ defmodule Sengoku.GameTest do
       assert new_state == old_state
     end
 
-    test "changes nothing if a required_move is pending" do
+    test "changes nothing if a move is pending" do
       old_state = %{
         current_player_id: 1,
         players: %{
@@ -312,7 +312,7 @@ defmodule Sengoku.GameTest do
         tiles: %{
           1 => %Tile{owner: 1, units: 4}
         },
-        required_move:
+        pending_move:
           %{
             # Not nil
           }
@@ -336,7 +336,7 @@ defmodule Sengoku.GameTest do
           1 => %Tile{units: 3, owner: 1, neighbors: [2]},
           2 => %Tile{units: 2, owner: 2, neighbors: [1]}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = Game.attack(old_state, 1, 2, {1, 1})
@@ -356,7 +356,7 @@ defmodule Sengoku.GameTest do
           1 => %Tile{units: 3, owner: 1, neighbors: [2]},
           2 => %Tile{units: 2, owner: 2, neighbors: [1]}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = Game.attack(old_state, 1, 2, {0, 2})
@@ -377,7 +377,7 @@ defmodule Sengoku.GameTest do
           1 => %Tile{units: 21, owner: 1, neighbors: [2]},
           2 => %Tile{units: 1, owner: 2, neighbors: [1]}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = Game.attack(old_state, 1, 2, {0, 1})
@@ -385,7 +385,7 @@ defmodule Sengoku.GameTest do
       assert new_state.tiles[2].units == 0
       assert new_state.tiles[2].owner == 1
 
-      assert new_state.required_move == %{
+      assert new_state.pending_move == %{
                from_id: 1,
                to_id: 2,
                min: 3,
@@ -404,7 +404,7 @@ defmodule Sengoku.GameTest do
           1 => %Tile{units: 2, owner: 1, neighbors: [2]},
           2 => %Tile{units: 1, owner: 2, neighbors: [1]}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = Game.attack(old_state, 1, 2, {0, 1})
@@ -426,7 +426,7 @@ defmodule Sengoku.GameTest do
           1 => %Tile{units: 2, owner: 1, neighbors: [2]},
           2 => %Tile{units: 1, owner: 2, neighbors: [1]}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = Game.attack(old_state, 1, 2, {0, 1})
@@ -442,7 +442,7 @@ defmodule Sengoku.GameTest do
           1 => %Tile{units: 1, owner: 1, neighbors: [2]},
           2 => %Tile{units: 1, owner: 2, neighbors: [1]}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = Game.attack(old_state, 1, 2)
@@ -456,7 +456,7 @@ defmodule Sengoku.GameTest do
           1 => %Tile{units: 1, owner: 2, neighbors: [2]},
           2 => %Tile{units: 1, owner: 2, neighbors: [1]}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = Game.attack(old_state, 1, 2)
@@ -470,7 +470,7 @@ defmodule Sengoku.GameTest do
           1 => %Tile{units: 1, owner: 1, neighbors: [2]},
           2 => %Tile{units: 1, owner: 1, neighbors: [1]}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = Game.attack(old_state, 1, 2)
@@ -484,14 +484,14 @@ defmodule Sengoku.GameTest do
           1 => %Tile{units: 1, owner: 1, neighbors: [3]},
           2 => %Tile{units: 1, owner: 2, neighbors: [3]}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = Game.attack(old_state, 1, 2)
       assert new_state == old_state
     end
 
-    test "changes nothing if a required_move is pending" do
+    test "changes nothing if a move is pending" do
       old_state = %{
         current_player_id: 1,
         players: %{
@@ -502,7 +502,7 @@ defmodule Sengoku.GameTest do
           1 => %Tile{units: 3, owner: 1, neighbors: [2]},
           2 => %Tile{units: 2, owner: 2, neighbors: [1]}
         },
-        required_move:
+        pending_move:
           %{
             # Not nil
           }
@@ -517,7 +517,7 @@ defmodule Sengoku.GameTest do
     test "starts a move" do
       old_state = %{
         selected_tile_id: 1,
-        required_move: nil,
+        pending_move: nil,
         end_turn_after_move: false,
         players: %{
           1 => %Player{active: true},
@@ -531,7 +531,7 @@ defmodule Sengoku.GameTest do
 
       new_state = Game.start_move(old_state, 1, 2)
 
-      assert new_state.required_move == %{
+      assert new_state.pending_move == %{
                from_id: 1,
                to_id: 2,
                min: 1,
@@ -555,7 +555,7 @@ defmodule Sengoku.GameTest do
           1 => %Player{active: true, unplaced_units: 0},
           2 => %Player{active: true, unplaced_units: 0}
         },
-        required_move: %{
+        pending_move: %{
           from_id: 1,
           to_id: 2,
           min: 3,
@@ -581,7 +581,7 @@ defmodule Sengoku.GameTest do
           1 => %Player{active: true, unplaced_units: 0},
           2 => %Player{active: true, unplaced_units: 0}
         },
-        required_move: %{
+        pending_move: %{
           from_id: 1,
           to_id: 2,
           min: 3,
@@ -605,7 +605,7 @@ defmodule Sengoku.GameTest do
           1 => %Player{active: true, unplaced_units: 0},
           2 => %Player{active: true, unplaced_units: 0}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = Game.move(old_state, 1, 2, 3)
@@ -623,7 +623,7 @@ defmodule Sengoku.GameTest do
           1 => %Player{active: true, unplaced_units: 0},
           2 => %Player{active: true, unplaced_units: 0}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = Game.move(old_state, 1, 2, 3)
@@ -641,7 +641,7 @@ defmodule Sengoku.GameTest do
           1 => %Player{active: true, unplaced_units: 0},
           2 => %Player{active: true, unplaced_units: 0}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = Game.move(old_state, 1, 2, 3)
@@ -659,7 +659,7 @@ defmodule Sengoku.GameTest do
           1 => %Player{active: true, unplaced_units: 0},
           2 => %Player{active: true, unplaced_units: 0}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = Game.move(old_state, 1, 2, 6)
@@ -677,7 +677,7 @@ defmodule Sengoku.GameTest do
           1 => %Player{active: true, unplaced_units: 0},
           2 => %Player{active: true, unplaced_units: 0}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = Game.move(old_state, 1, 2, 5)
@@ -695,7 +695,7 @@ defmodule Sengoku.GameTest do
           1 => %Player{active: true, unplaced_units: 0},
           2 => %Player{active: true, unplaced_units: 0}
         },
-        required_move: nil
+        pending_move: nil
       }
 
       new_state = Game.move(old_state, 1, 1, 3)
@@ -713,7 +713,7 @@ defmodule Sengoku.GameTest do
           1 => %Player{active: true, unplaced_units: 0},
           2 => %Player{active: true, unplaced_units: 0}
         },
-        required_move: %{
+        pending_move: %{
           from_id: 1,
           to_id: 2,
           min: 3,
@@ -725,7 +725,7 @@ defmodule Sengoku.GameTest do
 
       assert new_state.tiles[1].units == 2
       assert new_state.tiles[2].units == 3
-      assert is_nil(new_state.required_move)
+      assert is_nil(new_state.pending_move)
       assert new_state.current_player_id == 1
     end
 
@@ -740,7 +740,7 @@ defmodule Sengoku.GameTest do
           1 => %Player{active: true, unplaced_units: 0},
           2 => %Player{active: true, unplaced_units: 0}
         },
-        required_move: %{
+        pending_move: %{
           from_id: 1,
           to_id: 2,
           min: 3,
@@ -764,7 +764,7 @@ defmodule Sengoku.GameTest do
           1 => %Player{active: true, unplaced_units: 0},
           2 => %Player{active: true, unplaced_units: 0}
         },
-        required_move: %{
+        pending_move: %{
           from_id: 1,
           to_id: 2,
           min: 3,
@@ -788,7 +788,7 @@ defmodule Sengoku.GameTest do
           1 => %Player{active: true, unplaced_units: 0},
           2 => %Player{active: true, unplaced_units: 0}
         },
-        required_move: %{
+        pending_move: %{
           from_id: 1,
           to_id: 2,
           min: 3,

--- a/test/sengoku/game_test.exs
+++ b/test/sengoku/game_test.exs
@@ -536,8 +536,7 @@ defmodule Sengoku.GameTest do
                to_id: 2,
                min: 1,
                max: 2,
-               required: false,
-               end_turn: true
+               required: false
              }
     end
   end
@@ -581,8 +580,7 @@ defmodule Sengoku.GameTest do
           to_id: 2,
           min: 3,
           max: 4,
-          required: false,
-          end_turn: true
+          required: false
         }
       }
 
@@ -714,8 +712,7 @@ defmodule Sengoku.GameTest do
           to_id: 2,
           min: 3,
           max: 4,
-          required: true,
-          end_turn: false
+          required: true
         }
       }
 
@@ -743,8 +740,7 @@ defmodule Sengoku.GameTest do
           to_id: 2,
           min: 3,
           max: 4,
-          required: true,
-          end_turn: false
+          required: true
         }
       }
 
@@ -769,8 +765,7 @@ defmodule Sengoku.GameTest do
           to_id: 2,
           min: 3,
           max: 4,
-          required: true,
-          end_turn: false
+          required: true
         }
       }
 
@@ -795,8 +790,7 @@ defmodule Sengoku.GameTest do
           to_id: 2,
           min: 3,
           max: 4,
-          required: true,
-          end_turn: false
+          required: true
         }
       }
 
@@ -811,8 +805,7 @@ defmodule Sengoku.GameTest do
         current_player_id: 1,
         selected_tile_id: 1,
         pending_move: %{
-          required: false,
-          end_turn: true
+          required: false
         }
       }
 
@@ -840,8 +833,7 @@ defmodule Sengoku.GameTest do
         current_player_id: 1,
         selected_tile_id: 1,
         pending_move: %{
-          required: true,
-          end_turn: false
+          required: true
         }
       }
 


### PR DESCRIPTION
<img width="661" alt="Screen Shot 2020-06-01 at 8 01 39 PM" src="https://user-images.githubusercontent.com/664341/83465710-c77ee380-a442-11ea-8980-39aefd6b8b29.png">

## Why

If you accidentally click to move units but change your mind, your turn is over even if you choose to "move 0". This is especially annoying if you initiated the move accidentally.

Resolves #63

## What

This PR adds a "Cancel" button to the move UI.

## What Else

In an effort to further prevent accidental moves, this PR also:

- highlights (with a semitransparent stroke) clickable tiles
- only applies hover state to clickable tiles
- prevents interacting with non-intractable tiles (e.g. ones you can’t move or attack from)

And it improves the move UI by:

- setting the minimum to 1. Now that you can cancel if you don't want to move any, there's no reason to "Move zero units" anymore.
- Correctly defaults the form to move the average of the minimum and maximum units you can move, which was always the intention.

And it adds a refactor that:

- renames `required_move` to `pending_move` since it's not always required anymore, though it now has a `required` key to determine whether it is in fact required