### PR TITLE
A new LiveView tool to help with building boards

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -437,7 +437,6 @@ $tile-height: $tile-width * 1.1547005; // ratio of circumradius to inradius
     padding: 1em;
     border-radius: .25em;
     border: 1px solid transparent;
-    margin-bottom: .5em;
     transition: all .2s ease-in;
     cursor: pointer;
 

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -305,7 +305,7 @@ $tile-height: $tile-width * 1.1547005; // ratio of circumradius to inradius
 
 .Region {
   position: relative;
-  flex-basis: 16.67%;
+  flex-basis: 25%;
 
   &-value {
     position: absolute;
@@ -534,4 +534,10 @@ $tile-height: $tile-width * 1.1547005; // ratio of circumradius to inradius
 
 .opacity-25 {
   opacity: 0.25;
+}
+
+// Board Builder
+[phx-click="toggle_tile"],
+[phx-click="select_region"] {
+  cursor: pointer;
 }

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -531,3 +531,7 @@ $tile-height: $tile-width * 1.1547005; // ratio of circumradius to inradius
 .text-center {
   text-align: center;
 }
+
+.opacity-25 {
+  opacity: 0.25;
+}

--- a/lib/sengoku/board.ex
+++ b/lib/sengoku/board.ex
@@ -191,7 +191,7 @@ defmodule Sengoku.Board do
 
   defp build_tiles(board, additional_neighbors \\ []) do
     tile_ids_for_map =
-      Enum.reduce(board.regions, [], fn({_id, region}, tile_ids) ->
+      Enum.reduce(board.regions, [], fn {_id, region}, tile_ids ->
         tile_ids ++ region.tile_ids
       end)
 

--- a/lib/sengoku/board.ex
+++ b/lib/sengoku/board.ex
@@ -109,36 +109,9 @@ defmodule Sengoku.Board do
         4 => %Region{value: 4, tile_ids: [34, 35, 44, 45, 53, 54]},
         5 => %Region{value: 3, tile_ids: [46, 55, 56]},
         6 => %Region{value: 2, tile_ids: [18, 27, 36, 37]}
-      },
-      tiles:
-        build_tiles([
-          49,
-          50,
-          58,
-          59,
-          51,
-          52,
-          61,
-          32,
-          33,
-          41,
-          42,
-          43,
-          34,
-          35,
-          44,
-          45,
-          53,
-          54,
-          46,
-          55,
-          56,
-          18,
-          27,
-          36,
-          37
-        ])
+      }
     }
+    |> build_tiles()
   end
 
   def new("earth") do
@@ -155,56 +128,9 @@ defmodule Sengoku.Board do
         4 => %Region{value: 5, tile_ids: [14, 15, 23, 24, 25, 33, 34]},
         5 => %Region{value: 7, tile_ids: [16, 17, 18, 19, 26, 27, 28, 35, 36, 37, 44, 46]},
         6 => %Region{value: 2, tile_ids: [56, 57, 65, 66]}
-      },
-      tiles:
-        build_tiles(
-          [
-            10,
-            11,
-            12,
-            20,
-            21,
-            22,
-            30,
-            31,
-            40,
-            50,
-            51,
-            59,
-            60,
-            42,
-            43,
-            52,
-            53,
-            62,
-            63,
-            14,
-            15,
-            23,
-            24,
-            25,
-            33,
-            34,
-            16,
-            17,
-            18,
-            19,
-            26,
-            27,
-            28,
-            35,
-            36,
-            37,
-            44,
-            46,
-            56,
-            57,
-            65,
-            66
-          ],
-          additional_neighbors
-        )
+      }
     }
+    |> build_tiles(additional_neighbors)
   end
 
   @doc """
@@ -222,54 +148,9 @@ defmodule Sengoku.Board do
         5 => %Region{value: 3, tile_ids: [61, 70, 79, 80, 81, 82]},
         6 => %Region{value: 3, tile_ids: [39, 40, 41, 49, 59, 69]},
         7 => %Region{value: 6, tile_ids: [33, 34, 42, 43, 44, 52, 53]}
-      },
-      tiles:
-        build_tiles([
-          3,
-          12,
-          13,
-          21,
-          23,
-          30,
-          4,
-          5,
-          6,
-          7,
-          16,
-          25,
-          17,
-          27,
-          37,
-          45,
-          46,
-          47,
-          56,
-          63,
-          65,
-          73,
-          74,
-          83,
-          61,
-          70,
-          79,
-          80,
-          81,
-          82,
-          39,
-          40,
-          41,
-          49,
-          59,
-          69,
-          33,
-          34,
-          42,
-          43,
-          44,
-          52,
-          53
-        ])
+      }
     }
+    |> build_tiles()
   end
 
   def new("europe") do
@@ -285,79 +166,50 @@ defmodule Sengoku.Board do
         6 => %Region{value: 6, tile_ids: [26, 27, 35, 36, 37, 45, 46]},
         7 => %Region{value: 4, tile_ids: [54, 55, 56, 64, 65, 66, 74, 75, 84]},
         8 => %Region{value: 5, tile_ids: [18, 19, 28, 38, 47, 57]}
-      },
-      tiles:
-        build_tiles([
-          10,
-          18,
-          19,
-          20,
-          24,
-          25,
-          26,
-          27,
-          28,
-          29,
-          30,
-          31,
-          32,
-          33,
-          34,
-          35,
-          36,
-          37,
-          38,
-          40,
-          41,
-          42,
-          43,
-          44,
-          45,
-          46,
-          47,
-          50,
-          51,
-          52,
-          53,
-          54,
-          55,
-          56,
-          57,
-          58,
-          59,
-          60,
-          61,
-          62,
-          64,
-          65,
-          66,
-          67,
-          68,
-          69,
-          72,
-          74,
-          75,
-          77,
-          78,
-          81,
-          84
-        ])
+      }
     }
+    |> build_tiles()
   end
 
-  defp build_tiles(tile_ids_for_map, additional_neighbors \\ []) do
-    tile_ids_for_map
-    |> Enum.map(fn tile_id ->
-      neighbors =
-        Enum.filter(@all_neighbor_ids[tile_id], fn neighbor_id ->
-          neighbor_id in tile_ids_for_map
-        end)
+  def new("westeros") do
+    %__MODULE__{
+      name: "westeros",
+      players_count: 8,
+      regions: %{
+        1 => %Region{value: 2, tile_ids: [3, 4, 5, 6, 13, 14]},
+        2 => %Region{value: 4, tile_ids: [24, 25, 26, 34]},
+        3 => %Region{value: 3, tile_ids: [35, 44, 45]},
+        4 => %Region{value: 6, tile_ids: [22, 23, 32, 33, 42, 43]},
+        5 => %Region{value: 7, tile_ids: [51, 52, 53, 60, 61, 62, 70]},
+        6 => %Region{value: 3, tile_ids: [31, 40, 41, 50]},
+        7 => %Region{value: 3, tile_ids: [71, 72, 80, 81, 82, 83]},
+        8 => %Region{value: 3, tile_ids: [54, 55, 63, 64, 65]}
+      }
+    }
+    |> build_tiles()
+  end
 
-      neighbors = maybe_add_additional_neighbors(tile_id, neighbors, additional_neighbors)
+  defp build_tiles(board, additional_neighbors \\ []) do
+    tile_ids_for_map =
+      Enum.reduce(board.regions, [], fn({_id, region}, tile_ids) ->
+        tile_ids ++ region.tile_ids
+      end)
 
-      {tile_id, Tile.new(neighbors)}
-    end)
-    |> Enum.into(%{})
+    tiles =
+      tile_ids_for_map
+      |> Enum.map(fn tile_id ->
+        neighbors =
+          Enum.filter(@all_neighbor_ids[tile_id], fn neighbor_id ->
+            neighbor_id in tile_ids_for_map
+          end)
+
+        neighbors = maybe_add_additional_neighbors(tile_id, neighbors, additional_neighbors)
+
+        {tile_id, Tile.new(neighbors)}
+      end)
+      |> Enum.into(%{})
+
+    Map.put(board, :tiles, tiles)
   end
 
   defp maybe_add_additional_neighbors(tile_id, neighbors, additional_neighbor_pairs) do

--- a/lib/sengoku_web/live/board_builder_live.ex
+++ b/lib/sengoku_web/live/board_builder_live.ex
@@ -3,11 +3,12 @@ defmodule SengokuWeb.BoardBuilderLive do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok, assign(socket,
-      tiles: build_tiles(),
-      regions: 1..8,
-      current_region: 1
-    )}
+    {:ok,
+     assign(socket,
+       tiles: build_tiles(),
+       regions: 1..8,
+       current_region: 1
+     )}
   end
 
   @impl Phoenix.LiveView
@@ -71,16 +72,18 @@ defmodule SengokuWeb.BoardBuilderLive do
   def handle_event("toggle_tile", %{"tile_id" => tile_id_string}, socket) do
     tile_id = String.to_integer(tile_id_string)
     current_region = socket.assigns.current_region
+
     new_tiles =
       socket.assigns.tiles
-      |> Map.update!(tile_id, fn(tile_region) ->
-           case tile_region do
-             ^current_region ->
-               nil
-             _ ->
-               socket.assigns.current_region
-           end
-         end)
+      |> Map.update!(tile_id, fn tile_region ->
+        case tile_region do
+          ^current_region ->
+            nil
+
+          _ ->
+            socket.assigns.current_region
+        end
+      end)
 
     {:noreply, assign(socket, tiles: new_tiles)}
   end
@@ -95,9 +98,9 @@ defmodule SengokuWeb.BoardBuilderLive do
   defp build_tiles do
     1..85
     |> Enum.to_list()
-    |> Enum.map(fn(id) ->
-         {id, nil}
-       end)
+    |> Enum.map(fn id ->
+      {id, nil}
+    end)
     |> Enum.into(%{})
   end
 end

--- a/lib/sengoku_web/live/board_builder_live.ex
+++ b/lib/sengoku_web/live/board_builder_live.ex
@@ -6,7 +6,7 @@ defmodule SengokuWeb.BoardBuilderLive do
     {:ok, assign(socket,
       tiles: build_tiles(),
       regions: 1..8,
-      current_region: 1,
+      current_region: 1
     )}
   end
 

--- a/lib/sengoku_web/live/board_builder_live.ex
+++ b/lib/sengoku_web/live/board_builder_live.ex
@@ -1,0 +1,66 @@
+defmodule SengokuWeb.BoardBuilderLive do
+  use SengokuWeb, :live_view
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, tiles: build_tiles() )}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~L"""
+    <div class="Game">
+      <div class="Display">
+        <h1 class="Logo">
+          <a href="/">
+            <img src="<%= Routes.static_path(@socket, "/images/sengoku.svg") %>" alt="Sengoku" />
+          </a>
+        </h1>
+
+        <h2>Board Builder</h2>
+        <p>Instructions...</p>
+      </div>
+
+      <div class="Board">
+        <ul class="Tiles">
+          <%= for {tile_id, selected} <- @tiles do %>
+            <li
+              class="
+                Tile
+                <%= unless selected, do: "opacity-25" %>
+              "
+              id="tile_<%= tile_id %>"
+              phx-click="toggle"
+              phx-value-tile_id="<%= tile_id %>"
+            >
+              <svg viewBox="0 0 200 200" version="1.1">
+                <use href="#hexagon" />
+              </svg>
+              <span class="TileCenter"><%= tile_id %></span>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("toggle", %{"tile_id" => tile_id_string}, socket) do
+    tile_id = String.to_integer(tile_id_string)
+    new_tiles =
+      socket.assigns.tiles
+      |> Map.update!(tile_id, &(!&1))
+
+    {:noreply, assign(socket, tiles: new_tiles)}
+  end
+
+  defp build_tiles do
+    1..85
+    |> Enum.to_list()
+    |> Enum.map(fn(id) ->
+         {id, false}
+       end)
+    |> Enum.into(%{})
+  end
+end

--- a/lib/sengoku_web/router.ex
+++ b/lib/sengoku_web/router.ex
@@ -30,6 +30,7 @@ defmodule SengokuWeb.Router do
     get "/", GameController, :new
     post "/games", GameController, :create
     live "/games/:game_id", GameLive, layout: {SengokuWeb.LayoutView, :game}
+    live "/builder", BoardBuilderLive, layout: {SengokuWeb.LayoutView, :game}
   end
 
   scope "/" do

--- a/lib/sengoku_web/templates/game/new.html.eex
+++ b/lib/sengoku_web/templates/game/new.html.eex
@@ -32,6 +32,10 @@
       <label class="BorderRadio-label" for="board_europe">
         <b>Europe</b><br>8 players
       </label>
+      <input class="BorderRadio-input" id="board_westeros" type="radio" name="board" value="westeros" />
+      <label class="BorderRadio-label" for="board_westeros">
+        <b>Westeros</b><br>8 players
+      </label>
     </p>
     <p><input class="Button Button--primary" type="submit" value="New Game" /></p>
   <% end %>


### PR DESCRIPTION
<img width="1273" alt="Screen Shot 2020-06-06 at 3 34 08 PM" src="https://user-images.githubusercontent.com/664341/83953248-bf40f280-a80c-11ea-9014-445bb4ef0c97.png">

I've been using [this tool](hextml.playest.net/) to build hex grids for the game's maps, but would like to add something to Sengoku to help with this. This PR introduces a new LiveView at `/builder` that lets you "paint" the board with the different regions. You still have to manually enter the board data in `lib/sengoku/board.ex` for now...

This PR also updates the `Board` module to no longer require passing the board's tiles under both `regions:` and `tiles:` keys. The `tiles:` key is now built from the tiles in the `regions:` key, since every tile must belong to a region.

## Soon

I'd eventually like the ability to export a board, either to a database or a string you could paste in when creating a new game in order to play on a custom board. This is being tracked in #71

## And a new board! 🐉 

What good is a board builder if I'm not going to use it, so in the screenshot above you can see my attempt as a new "Westeros" map with lots of connections, based on this image I found online:

<img width="333" alt="Screen Shot 2020-06-06 at 3 35 32 PM" src="https://user-images.githubusercontent.com/664341/83953459-991c5200-a80e-11ea-9db6-556d595d1fff.png">

It's a bit awkwardly compressed, particularly in The North, but fun!