### PR TITLE
Whoops, fix markdown list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,30 +37,32 @@ Want to improve the AI? Great! Computer players implement the `Sengoku.AI` behav
 
 1. Copy the current AI module and its tests. From the command line:
 
-  ```
-  cp lib/sengoku/ai/smart.ex lib/sengoku/ai/smarter.ex
-  cp test/sengoku/ai/smart_test.exs test/sengoku/ai/smarter_test.exs
-  ```
+    ```
+    cp lib/sengoku/ai/smart.ex lib/sengoku/ai/smarter.ex
+    cp test/sengoku/ai/smart_test.exs test/sengoku/ai/smarter_test.exs
+    ```
+
 2. I’d like to automate this, but with `lib/sengoku/ai/smarter.ex` manually rename `Sengoku.AI.Smart` to `Sengoku.AI.Smarter`, and within `test/sengoku/ai/smarter_test.exs` rename `Sengoku.AI.SmartTest` to `Sengoku.AI.SmarterTest`.
 3. Run `mix test` to ensure everything’s working.
 4. Run `mix ai.arena Sengoku.AI.Smarter` with your new AI module:
 
-  ```
-  Starting 2000 games with Sengoku.AI.Smarter as Player 1
-  against Sengoku.AI.Smart as all other players
+    ```
+    Starting 2000 games with Sengoku.AI.Smarter as Player 1
+    against Sengoku.AI.Smart as all other players
 
-   Player                         | Win %
-  --------------------------------|-------
-   1 (Sengoku.AI.Smarter)         |  11.9%
-   2 (Sengoku.AI.Smart)           |  11.8%
-   3 (Sengoku.AI.Smart)           |  13.6%
-   4 (Sengoku.AI.Smart)           |  13.7%
-   5 (Sengoku.AI.Smart)           |  12.4%
-   6 (Sengoku.AI.Smart)           |  12.3%
-   7 (Sengoku.AI.Smart)           |  11.5%
-   8 (Sengoku.AI.Smart)           |  12.8%
-  ```
+     Player                         | Win %
+    --------------------------------|-------
+     1 (Sengoku.AI.Smarter)         |  11.9%
+     2 (Sengoku.AI.Smart)           |  11.8%
+     3 (Sengoku.AI.Smart)           |  13.6%
+     4 (Sengoku.AI.Smart)           |  13.7%
+     5 (Sengoku.AI.Smart)           |  12.4%
+     6 (Sengoku.AI.Smart)           |  12.3%
+     7 (Sengoku.AI.Smart)           |  11.5%
+     8 (Sengoku.AI.Smart)           |  12.8%
+    ```
 
-  (With `mix ai.arena`, at least on the default `"westeros"` map, win percentages should be even within a few percentage points.)
+    (With `mix ai.arena`, at least on the default `"westeros"` map, win percentages should be even within a few percentage points.)
+
 5. Now change how `Sengoku.AI.Smarter` works! Continue running `mix ai.arena Sengoku.AI.Smarter` to test the impact of your changes against the default AI.
 6. When you’ve made an improvement, merge your changes back into `Sengoku.AI.Smart` and consider opening a Pull Request with the improvements!


### PR DESCRIPTION
The markdown list lost its formatting due to the indented code blocks:

<img width="1033" alt="Screen Shot 2020-06-17 at 3 36 07 PM" src="https://user-images.githubusercontent.com/664341/84942057-46655480-b0b0-11ea-9a77-a215339d9a3c.png">
